### PR TITLE
Set MEDIA_ROOT to a value without a leading slash

### DIFF
--- a/tutors3/patches/openedx-common-settings
+++ b/tutors3/patches/openedx-common-settings
@@ -16,3 +16,5 @@ is_secure = {{ "True" if S3_USE_SSL else "False" }}
 [s3]
 host = {{ S3_HOST }}:{{ S3_PORT }}
 calling_format = boto.s3.connection.OrdinaryCallingFormat""")
+
+MEDIA_ROOT = "openedx/media/"


### PR DESCRIPTION
Setting S3BotoStorage.location to a path with a leading slash causes
Django to throw an ImproperlyConfigured exception. Tutor hard-codes
this path to "/openedx/media", so use "openedx/media" instead.

Fixes #8.