### PR TITLE
Add release management scaffolding

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,9 @@
+[bumpversion]
+commit = True
+tag = True
+sign_tags = True
+current_version = 0.0.1
+
+[bumpversion:file:CHANGELOG.md]
+search = Unreleased
+replace = Version {new_version} ({now:%Y-%m-%d})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## Unreleased
+
+* [Enhancement] Support S3Boto3Storage, instead of the deprecated
+  S3BotoStorage.
+* [Enhancement] No longer rely on buckets with a public ACL, use
+  query-string authentication instead.
+
+## Version 0.0.1 (2019-10-10)
+
+**Experimental. Do not use in production.**
+
+* Initial Git import

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,78 @@
+Developer notes
+===============
+
+This document is for people who maintain and contribute to this
+repository.
+
+
+How to run tests
+----------------
+
+This repo uses [tox](https://tox.readthedocs.io/) for unit and
+integration tests. It does not install `tox` for you, you should
+follow [the installation
+instructions](https://tox.readthedocs.io/en/latest/install.html) if
+your local setup does not yet include `tox`.
+
+You are encouraged to set up your checkout such
+that the tests run on every commit, and on every push. To do so, run
+the following command after checking out this repository:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Once your checkout is configured in this manner, every commit will run
+a code style check (with [Flake8](https://flake8.pycqa.org/)), and
+every push to a remote topic branch will result in a full `tox` run.
+
+In addition, we use [GitHub
+Actions](https://docs.github.com/en/actions) to run the same checks
+on every push to GitHub.
+
+*If you absolutely must,* you can use the `--no-verify` flag to `git
+commit` and `git push` to bypass local checks, and rely on GitHub
+Actions alone. But doing so is strongly discouraged.
+
+
+How to cut a release
+--------------------
+
+This repository uses
+[bumpversion](https://pypi.org/project/bumpversion/) for managing new
+releases.
+
+Before cutting a new release, open `CHANGELOG.md` and add a new
+section like this:
+
+```markdown
+## Unreleased
+
+* [Bug fix] Description of bug fix
+* [Enhancement] Description of enhancement
+```
+
+Commit these changes on `main` as you normally would.
+
+Then, use `tox -e bumpversion` to increase the version number:
+
+-   `tox -e bumpversion patch`: creates a new point release (such as 3.6.1)
+-   `tox -e bumpversion minor`: creates a new minor release, with the patch level set to 0 (such as 3.7.0)
+-   `tox -e bumpversion major`: creates a new major release, with the minor and patch levels set to 0 (such as 4.0.0)
+
+This creates a new commit, and also a new tag, named `v<num>`, where
+`<num>` is the new version number.
+
+Push these two commits (the one for the changelog, and the version
+bump) to `origin`. Make sure you push the `v<num>` tag to `origin` as
+well.
+
+Then, build a new `sdist` package, and [upload it to
+PyPI](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives)
+(with [twine](https://packaging.python.org/key_projects/#twine)):
+
+```bash
+rm dist/* -f
+./setup.py sdist
+twine upload dist/*
+```

--- a/tox.ini
+++ b/tox.ini
@@ -23,3 +23,16 @@ commands =
 skip_install = True
 deps = flake8
 commands = flake8
+
+[testenv:bumpversion]
+skip_install = True
+passenv =
+  # Git can only find its global configuration if it knows where the
+  # user's HOME is.
+  HOME
+  # We set sign_tags in .bumpversion.cfg, so pass in the GnuPG agent
+  # reference to avoid having to retype the passphrase for an
+  # already-cached private key.
+  GPG_AGENT_INFO
+deps = bump2version
+commands = bump2version {posargs}


### PR DESCRIPTION
Add a few bits and pieces that make release management easier:

* Add configuration for `bump2version` (the maintained fork/workalike of bumpversion).
* Add a tox testenv, `bumpversion`, so that a release manager can easily cut a new release with `tox -e bumpversion`.
* Add `HACKING.md` explaining the process.
* Add `CHANGELOG.md` for tracking changes.

Reference: <https://pypi.org/project/bump2version/>