### PR TITLE
docs: Update README to mention pip install from GitHub

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -8,3 +8,5 @@ current_version = 0.1.1
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased
 replace = Version {new_version} ({now:%Y-%m-%d})
+
+[bumpversion:file:README.md]

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ S3-compatible storage platform *as part of Tutor,* please consider the
 Installation
 ------------
 
-    pip install tutor-contrib-s3
+    pip install git+https://github.com/hastexo/tutor-contrib-s3@v0.1.1
 
-Then, to enable this plugin, run::
+Then, to enable this plugin, run:
 
     tutor plugins enable s3
 


### PR DESCRIPTION
As long as we don't have a release up on PyPI, instruct people to
install from Git, pointing them to the most recent release.

Update .bumpversion.cfg so that we update the README with the latest
version on every release.

Also, fix a double colon ("::") in the README that was left over from
the ReST→Markdown conversion.
