### PR TITLE
fix: Only set AWS_S3_ENDPOINT_URL if not using AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,27 @@ Configuration
 
 * `OPENEDX_AWS_ACCESS_KEY` (default: `""`)
 * `OPENEDX_AWS_SECRET_ACCESS_KEY` (default: `""`)
-* `S3_HOST` (default: `"s3.amazonaws.com"`)
-* `S3_REGION` (default: `""`)
-* `S3_PORT` (default: `443`)
+* `S3_HOST` (default: `None`) - set only if using any other service than AWS S3
+* `S3_PORT` (default: `None`) - set only if using any other service than AWS S3
+* `S3_REGION` (default: ``)
 * `S3_USE_SSL` (default: `true`)
 * `S3_STORAGE_BUCKET` (default: `"openedx"`)
 * `S3_FILE_UPLOAD_BUCKET` (default: `"{{ S3_STORAGE_BUCKET }}"`)
 * `S3_PROFILE_IMAGE_BUCKET` (default: `"{{ S3_STORAGE_BUCKET }}"`)
 * `S3_GRADE_BUCKET` (default: `"{{ S3_STORAGE_BUCKET }}"`)
-* `S3_ADDRESSING_STYLE` (default: `"virtual"`)
+* `S3_ADDRESSING_STYLE` (default: `"auto"`)
 * `S3_SIGNATURE_VERSION` (default: `"s3v4"`)
 
 These values can be modified with `tutor config save --set
 PARAM_NAME=VALUE` commands.
 
 Depending on the nature and configuration of your S3-compatible
-service, some of these values may be required to set. For example, on
-AWS S3, you will need to set `S3_REGION` to a non-empty value. For a
-Ceph Object Gateway that doesn’t set
-[rgw_dns_name](https://docs.ceph.com/en/latest/radosgw/config-ref/#confval-rgw_dns_name),
-you will need `S3_ADDRESSING_STYLE: path`.
+service, some of these values may be required to set.
+
+* If using AWS S3, you will need to set `S3_REGION` to a non-empty value. 
+  And make sure `S3_ADDRESSING_STYLE` is set to `"auto"`.
+* If you want to use an alternative S3-compatible service, you need to set the 
+  `S3_HOST` and `S3_PORT` parameters.
+* For a Ceph Object Gateway that doesn’t set
+  [rgw_dns_name](https://docs.ceph.com/en/latest/radosgw/config-ref/#confval-rgw_dns_name),
+  you will need `S3_ADDRESSING_STYLE: path`.

--- a/tutors3/patches/openedx-common-settings
+++ b/tutors3/patches/openedx-common-settings
@@ -8,7 +8,11 @@ ORA2_FILEUPLOAD_BACKEND = "s3"
 FILE_UPLOAD_STORAGE_BUCKET_NAME = "{{ S3_FILE_UPLOAD_BUCKET }}"
 
 AWS_S3_SIGNATURE_VERSION = "{{ S3_SIGNATURE_VERSION }}"
-AWS_S3_ENDPOINT_URL = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ S3_HOST }}:{{ S3_PORT }}"
+
+{% if S3_HOST %}
+AWS_S3_ENDPOINT_URL = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ S3_HOST }}{% if S3_PORT %}:{{ S3_PORT }}{% endif %}"
+{% endif %}
+
 AWS_S3_USE_SSL = {{ "True" if S3_USE_SSL else "False" }}
 AWS_S3_SECURE_URLS = {{ "True" if S3_USE_SSL else "False" }}
 AWS_DEFAULT_ACL = None # inherit from the bucket

--- a/tutors3/plugin.py
+++ b/tutors3/plugin.py
@@ -9,8 +9,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 config = {
     "defaults": {
         "VERSION": __version__,
-        "HOST": "s3.amazonaws.com",
-        "PORT": "443",
+        "HOST": None,
+        "PORT": None,
         "REGION": "",
         "USE_SSL": "True",
         "STORAGE_BUCKET": "openedx",
@@ -19,7 +19,7 @@ config = {
         "GRADE_BUCKET": "{{ S3_STORAGE_BUCKET }}",
         "PROFILE_IMAGE_CUSTOM_DOMAIN": "",
         "PROFILE_IMAGE_MAX_AGE": "31536000",
-        "ADDRESSING_STYLE": "virtual",
+        "ADDRESSING_STYLE": "auto",
         "SIGNATURE_VERSION": "s3v4",
     },
 }


### PR DESCRIPTION
Setting a value for `AWS_S3_ENDPOINT_URL` overrides
`AWS_S3_ADDRESSING_STYLE` settings.
Not setting it allows `django-storages` to build the correct AWS path
incorporating `AWS_S3_ADDRESSING_STYLE` and
`AWS_S3_ADDRESSING_REGION`.
So we should only set `AWS_S3_ENDPOINT_URL` if we explicitly want to
use a different S3 host than AWS.

Fixes issue #22.