### PR TITLE
fix: Honour S3_USE_SSL when setting AWS_S3_ENDPOINT_URL

### DIFF
--- a/tutors3/patches/openedx-common-settings
+++ b/tutors3/patches/openedx-common-settings
@@ -10,7 +10,7 @@ FILE_UPLOAD_STORAGE_BUCKET_NAME = "{{ S3_FILE_UPLOAD_BUCKET }}"
 AWS_S3_SIGNATURE_VERSION = "{{ S3_SIGNATURE_VERSION }}"
 
 {% if S3_HOST %}
-AWS_S3_ENDPOINT_URL = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ S3_HOST }}{% if S3_PORT %}:{{ S3_PORT }}{% endif %}"
+AWS_S3_ENDPOINT_URL = "{{ "https" if S3_USE_SSL else "http" }}://{{ S3_HOST }}{% if S3_PORT %}:{{ S3_PORT }}{% endif %}"
 {% endif %}
 
 AWS_S3_USE_SSL = {{ "True" if S3_USE_SSL else "False" }}


### PR DESCRIPTION
We previously used `ENABLE_HTTPS` when constructing `AWS_S3_ENDPOINT_URL` to determine whether we wanted to connect to `S3_HOST` via HTTP or HTTPS. `Use S3_USE_SSL` instead, as we do for the other SSL-related settings.