### PR TITLE
docs: Remove wrapped paragraphs in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,17 +9,13 @@ assignees: ''
 
 # Summary
 
-Replace this with a short summary (one sentence or short paragraph) of
-the issue you are seeing.
+Replace this with a short summary (one sentence or short paragraph) of the issue you are seeing.
 
 ## What I did
 
-Explain the steps you undertook that led to the unexpected behavior
-you are observing. Please include relevant documentation snippets,
-such as the `S3_*` settings from Tutor’s `config.yml`. It’s OK to
-remove or mask credentials (like your `OPENEDX_AWS_*` settings), but
-otherwise try to err on the side of sharing more rather than less
-information.
+Explain the steps you undertook that led to the unexpected behavior you are observing. Please include relevant documentation snippets, such as the `S3_*` settings from Tutor’s `config.yml`.
+
+It’s OK to remove or mask credentials (like your `OPENEDX_AWS_*` settings), but otherwise try to err on the side of sharing more rather than less information.
 
 ## What I expected to happen
 
@@ -31,31 +27,18 @@ Explain how Tutor behaved differently than you expected.
 
 ## My environment
 
-Please add some information about the environment that you’re working
-in. At a minimum, include these items:
+Please add some information about the environment that you’re working in. At a minimum, include these items:
 
 * Tutor version: (Insert the Tutor version you are using.)
-* `tutor-contrib-s3` version: (Insert the plugin version you are
-  using. If you installed from Git, enter the tag or branch name, or
-  the commit reference)
+* `tutor-contrib-s3` version: (Insert the plugin version you are using. If you installed from Git, enter the tag or branch name, or the commit reference.)
 
-Additionally, you might also want to add any of the items below, if
-you think they might be relevant to the bug:
+Additionally, you might also want to add any of the items below, if you think they might be relevant to the bug:
 
-* Kubernetes versions: (If you are reporting a bug that
-  applies to deploying this plugin with `tutor k8s`, add your `kubectl
-  version` output. Otherwise, remove this item.)
-* Docker/Podman version: (If you are running `tutor local`, the output
-  of `docker version` might be relevant.)
-* Platform details: (Some issues are specific to individual cloud
-  platforms. It may help if you could include whether you’re running
-  on AWS, on OpenStack, on Digital Ocean etc.)
-* S3 implementation details: (Some issues are specific to AWS S3,
-  others to Ceph Object Gateway, others to other S3 implementations.
-  It may help if you could include some details about what runs your
-  S3 API.)
+* Kubernetes versions: (If you are reporting a bug that applies to deploying this plugin with `tutor k8s`, add your `kubectl version` output. Otherwise, remove this item.)
+* Docker/Podman version: (If you are running `tutor local`, the output of `docker version` might be relevant.)
+* Platform details: (Some issues are specific to individual cloud platforms. It may help if you could include whether you’re running on AWS, on OpenStack, on Digital Ocean etc.)
+* S3 implementation details: (Some issues are specific to AWS S3, others to Ceph Object Gateway, others to other S3 implementations. It may help if you could include some details about what runs your S3 API.)
 
-**Additional context**
+## Additional context
 
-If there’s any other context you’d like to share, please add it
-here. Otherwise, you can delete this section.
+If there’s any other context you’d like to share, please add it here. Otherwise, you can delete this section.


### PR DESCRIPTION
When rendered in GitHub for opening an issue, the 80-column line wrap looks bad in the preview. Since everything about the bug report template is for making it easy to submit good bug reports, and UI impressions matter for perceived ease of use, remove the extraneous newlines and let the GitHub issue UI reflow the text as needed.