### PR TITLE
feat: add ability to disable profile pictures to use S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Plugin configuration
 * `S3_USE_SSL` (default: `true`)
 * `S3_STORAGE_BUCKET` (default: `"openedx"`)
 * `S3_FILE_UPLOAD_BUCKET` (default: `"{{ S3_STORAGE_BUCKET }}"`)
-* `S3_PROFILE_IMAGE_BUCKET` (default: `"{{ S3_STORAGE_BUCKET }}"`)
+* `S3_PROFILE_IMAGE_BUCKET` (default: `""`, meaning profile images are
+  stored in the filesystem, rather than in S3)
 * `S3_GRADE_BUCKET` (default: `"{{ S3_STORAGE_BUCKET }}"`)
 * `S3_ADDRESSING_STYLE` (default: `"auto"`)
 * `S3_SIGNATURE_VERSION` (default: `"s3v4"`)

--- a/tutors3/patches/openedx-lms-common-settings
+++ b/tutors3/patches/openedx-lms-common-settings
@@ -1,3 +1,4 @@
+{% if S3_PROFILE_IMAGE_BUCKET %}
 PROFILE_IMAGE_BACKEND = {
     "class": DEFAULT_FILE_STORAGE,
     "options": {
@@ -9,3 +10,4 @@ PROFILE_IMAGE_BACKEND = {
         "base_url": "dummyprofileimagebaseurl",
     },
 }
+{% endif %}

--- a/tutors3/plugin.py
+++ b/tutors3/plugin.py
@@ -15,7 +15,7 @@ config = {
         "USE_SSL": True,
         "STORAGE_BUCKET": "openedx",
         "FILE_UPLOAD_BUCKET": "{{ S3_STORAGE_BUCKET }}",
-        "PROFILE_IMAGE_BUCKET": "{{ S3_STORAGE_BUCKET }}",
+        "PROFILE_IMAGE_BUCKET": "",
         "GRADE_BUCKET": "{{ S3_STORAGE_BUCKET }}",
         "PROFILE_IMAGE_CUSTOM_DOMAIN": "",
         "PROFILE_IMAGE_MAX_AGE": "31536000",


### PR DESCRIPTION
Without this patch when the plugin is activated all file are saved in an
S3 Bucket or an API-compatible storage. We don't have the option to keep
the profile pictures in the filesystem.

This is a problem because Open edX makes it possible to configure
individually each type of data, such as Grades, Reports, Profiles
Pictures, ORA2 files, etc.

This patch solves the problem by add the ability to continue using the
filesystem for profile pictures when the plugin is activated.

Use:
- When `S3_PROFILE_IMAGE_BUCKET` is empty the profile pictures will be
  saved in filesystem. The default `PROFILE_IMAGE_BACKEND` won't be
  overwritten.

- When `S3_PROFILE_IMAGE_BUCKET` is set the profile pictures will
  be saved in an S3 Bucket that must have a public ACL. The
  `PROFILE_IMAGE_BACKEND` will be overwritten.

Resolves: #40