### PR TITLE
build: add python virtual environment as a flake8 exclusion directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,15 @@
 !.gitignore
 TODO
 __pycache__
-*.egg-info/
 /build/
 /dist/
+
+# python virtual environment
+venv*
+
+# output tox files and folders
+*.egg-info/
+.eggs
+.tox
+tests
+!tests/.placeholder

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ python =
 
 [flake8]
 ignore = E124,W504
-exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,src
+exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,src,venv*
 
 [testenv]
 setenv =


### PR DESCRIPTION
Hello everyone,

Here, I'm using a simple python virtual environment to work with this project and I had these problems:

- Need to execute `commit` and `push` with `--no-verify` because flake8 is not bypassing the python virtual
environment and it causes errors. 
- Also are unable to execute a `rebase` without deleting tox files and `venv` folder before.

![image](https://user-images.githubusercontent.com/6977922/166839695-06ff74d0-d082-4649-a947-30ef46face4e.png)

To solve these problems I added the `venv*` folder in flake8 exclude property and also added generated tox files in `.gitignore` file.

What do you think about that? Do these changes make sense to you?
How is your machine setup?