### PR TITLE
fix: Limit the plugin to Open edX Maple release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor"],
+    install_requires=["tutor<14"],
     setup_requires=["setuptools-scm"],
     entry_points={"tutor.plugin.v0": ["s3 = tutors3.plugin"]},
     classifiers=[


### PR DESCRIPTION
From version 14, Tutor uses the Open edX Nutmeg release. Until we add
support for that release, limit the plugin to Tutor versions <14.

After this PR is merged, we will create a branch called `maple`. The work to 
update the plugin to Nutmeg and Tutor v1 plugin API will continue in 
the `main` branch.