### PR TITLE
refactor: Use Tutor v1 plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Use Tutor v1 plugin API.
+
 ## Version 0.2.2 (2022-05-05)
 
 * [Enhancement] If `S3_PROFILE_IMAGE_BUCKET` is not set, store profile 

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor<14"],
+    install_requires=["tutor <14, >=13.2.0"],
     setup_requires=["setuptools-scm"],
-    entry_points={"tutor.plugin.v0": ["s3 = tutors3.plugin"]},
+    entry_points={"tutor.plugin.v1": ["s3 = tutors3.plugin"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/tutors3/plugin.py
+++ b/tutors3/plugin.py
@@ -1,5 +1,8 @@
 import os
+import pkg_resources
 from glob import glob
+
+from tutor import hooks
 
 from .__about__ import __version__
 
@@ -26,11 +29,41 @@ config = {
 }
 
 
-def patches():
-    all_patches = {}
-    for path in glob(os.path.join(HERE, "patches", "*")):
-        with open(path) as patch_file:
-            name = os.path.basename(path)
-            content = patch_file.read()
-            all_patches[name] = content
-    return all_patches
+# Add the "templates" folder as a template root
+hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(
+    pkg_resources.resource_filename("tutors3", "templates")
+)
+# Render the "build" and "apps" folders
+hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
+    [
+        ("s3/build", "plugins"),
+        ("s3/apps", "plugins"),
+    ],
+)
+# Load patches from files
+for path in glob(
+    os.path.join(
+        pkg_resources.resource_filename("tutors3", "patches"),
+        "*",
+    )
+):
+    with open(path, encoding="utf-8") as patch_file:
+        hooks.Filters.ENV_PATCHES.add_item(
+            (os.path.basename(path), patch_file.read())
+        )
+# Add configuration entries
+hooks.Filters.CONFIG_DEFAULTS.add_items(
+    [
+        (f"S3_{key}", value)
+        for key, value in config.get("defaults", {}).items()
+    ]
+)
+hooks.Filters.CONFIG_UNIQUE.add_items(
+    [
+        (f"S3_{key}", value)
+        for key, value in config.get("unique", {}).items()
+    ]
+)
+hooks.Filters.CONFIG_OVERRIDES.add_items(
+    list(config.get("overrides", {}).items())
+)


### PR DESCRIPTION
Use Tutor v1 plugin API instead of the legacy v0 API.

Reference: https://github.com/overhangio/cookiecutter-tutor-plugin#migrating-from-v0-plugins