### PR TITLE
Prepare release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 tag = True
 sign_tags = True
 message = build: Version {new_version}
-current_version = 0.3.0
+current_version = 1.0.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Version 1.0.0 (2022-08-03)
 
 * [BREAKING CHANGE] Support Tutor 14 and Open edX Nutmeg. This entails
   a configuration format change from JSON to YAML, meaning that from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-## Version 0.3.0 (2022-06-29)
+## Unreleased
 
 * [BREAKING CHANGE] Support Tutor 14 and Open edX Nutmeg. This entails
   a configuration format change from JSON to YAML, meaning that from
   version 1.0.0 this plugin only supports Tutor versions from 14.0.0
   (and with that, only Open edX versions from Nutmeg).
+
+## Version 0.3.0 (2022-06-29)
+
 * [Enhancement] Use Tutor v1 plugin API.
 
 ## Version 0.2.2 (2022-05-05)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ appropriate one:
 Installation
 ------------
 
-    pip install git+https://github.com/hastexo/tutor-contrib-s3@v0.3.0
+    pip install git+https://github.com/hastexo/tutor-contrib-s3@v1.0.0
 
 Then, to enable this plugin, run:
 


### PR DESCRIPTION
As of this release, the plugin supports Tutor 14 and hence Open edX Nutmeg.