### PR TITLE
chore: bump supported tutor versions to work on tutor 16 for palm

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,6 +12,8 @@ jobs:
         python-version:
           - 3.8
           - 3.9
+          - "3.10"
+          - 3.11
 
     steps:
     - name: Check out code

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,3 +13,17 @@ py39:
   script:
     - pip install tox
     - tox -e gitlint,py39,flake8
+
+py310:
+  image: python:3.10
+  stage: build
+  script:
+    - pip install tox
+    - tox -e gitlint,py310,flake8
+
+py311:
+  image: python:3.11
+  stage: build
+  script:
+    - pip install tox
+    - tox -e gitlint,py311,flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support Tutor 16 and Open edX Palm, Python 3.10, and Python 3.11.
+
 ## Version 1.1.0 (2023-03-21)
 
 * [Enhancement] Support Tutor 15 and Open edX Olive.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ appropriate one:
 | Maple            | `>=13.2, <14`[^1] | `maple`       | 0.3.x          |
 | Nutmeg           | `>=14.0, <15`     | `main`        | 1.x.x          |
 | Olive            | `>=15.0, <16`     | `main`        | 1.x.x          |
+| Palm             | `>=16.0, <17`     | `main`        | 1.x.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,
@@ -67,16 +68,16 @@ printroot)/config.yaml`.
 Depending on the nature and configuration of your S3-compatible
 service, some of these values may be required to set.
 
-* If using AWS S3, you will need to set `S3_REGION` to a non-empty value. 
-  And make sure `S3_ADDRESSING_STYLE` is set to `"auto"` (default) and 
+* If using AWS S3, you will need to set `S3_REGION` to a non-empty value.
+  And make sure `S3_ADDRESSING_STYLE` is set to `"auto"` (default) and
   `S3_CUSTOM_DOMAIN` is set to `""` (default).
-* If you want to use an alternative S3-compatible service, you need to set the 
+* If you want to use an alternative S3-compatible service, you need to set the
   `S3_HOST` and `S3_PORT` parameters.
 * For a Ceph Object Gateway that doesn’t set
   [rgw_dns_name](https://docs.ceph.com/en/latest/radosgw/config-ref/#confval-rgw_dns_name),
   you will need `S3_ADDRESSING_STYLE: path`.
-* Due to limitations in Open edX, if you are using `s3v4` signatures, your 
-  `S3_PROFILE_IMAGE_BUCKET` must have a public ACL and you must set 
+* Due to limitations in Open edX, if you are using `s3v4` signatures, your
+  `S3_PROFILE_IMAGE_BUCKET` must have a public ACL and you must set
   `S3_PROFILE_IMAGE_CUSTOM_DOMAIN`.
 
 Guide for configuring buckets for AWS S3

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <16, >=14.0.0"],
+    install_requires=["tutor <17, >=14.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={"tutor.plugin.v1": ["s3 = tutors3.plugin"]},
     classifiers=[
@@ -35,5 +35,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = gitlint,py{38,39},flake8
+envlist = gitlint,py{38,39,310,311},flake8
 
 [gh-actions]
 python =
     3.8: gitlint,py38,flake8
     3.9: gitlint,py39,flake8
+    3.10: gitlint,py310,flake8
+    3.11: gitlint,py311,flake8
 
 [flake8]
 ignore = E124,W504


### PR DESCRIPTION
This plugin works perfectly with the latest release of tutor as-is, so this change expands its compatibility to work with the latest relese.