### PR TITLE
docs: Update version compatibility matrix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ appropriate one:
 |------------------|-------------------|---------------|----------------|
 | Lilac            | `>=12.0, <13`     | Not supported | Not supported  |
 | Maple            | `>=13.2, <14`[^1] | `maple`       | 0.3.x          |
-| Nutmeg           | `>=14.0, <15`     | `main`        | 1.x.x          |
-| Olive            | `>=15.0, <16`     | `main`        | 1.x.x          |
-| Palm             | `>=16.0, <17`     | `main`        | 1.x.x          |
+| Nutmeg           | `>=14.0, <15`     | `main`        | 1.0.x          |
+| Olive            | `>=15.0, <16`     | `main`        | 1.1.x          |
+| Palm             | `>=16.0, <17`     | `main`        | 1.2.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,


### PR DESCRIPTION
We started supporting Nutmeg with 1.0.0, Olive with 1.1.0, and Palm with 1.2.0. Technically all three Open edX releases *should* work in conjunction with whatever is the latest state of `main`, but it probably doesn't hurt to recommend that people use a minor version to match the Open edX release which we regularly test at the time we tag the minor.

Thus, update the version compatibility matrix in the README accordingly.