### PR TITLE
Bump tutor requirements to allow v17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support Tutor 17 and Open edX Quince.
+
 ## Version 1.2.0 (2023-07-21)
 
 * [Enhancement] Support Tutor 16 and Open edX Palm, Python 3.10, and Python 3.11.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ appropriate one:
 | Nutmeg           | `>=14.0, <15`     | `main`        | 1.0.x          |
 | Olive            | `>=15.0, <16`     | `main`        | 1.1.x          |
 | Palm             | `>=16.0, <17`     | `main`        | 1.2.x          |
+| Quince           | `>=17.0, <18`     | `main`        | 1.3.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <17, >=14.0.0"],
+    install_requires=["tutor <18, >=14.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={"tutor.plugin.v1": ["s3 = tutors3.plugin"]},
     classifiers=[


### PR DESCRIPTION
## Description

This PR bumps Tutor to v17 to support Quince. Also, it updates the changelog and the compatibility matrix.