### PR TITLE
build: Exclude generated Tutor configuration from flake8 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
 
 [flake8]
 ignore = E124,W504
-exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,src
+exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,src,tests/tutor-sandbox/env
 
 [testenv]
 setenv =


### PR DESCRIPTION
Until Tutor 17, just enabling a plugin with `tutor plugin enable` would not recreate the configuration, meaning the `tests/tutor-sandbox/env` directory would remain empty.
    
As of https://github.com/overhangio/tutor/pull/957, however, `tutor plugin enable` does automatically also run `tutor config save`, generating a full Tutor configuration.
    
This means that unless configured otherwise, with Tutor 17 our flake8 checks would test code generated by Tutor, rather than just that generated by our plugin.
    
Thus, to make our tests not break once we bump our dependencies to support Tutor 17, exclude the `tests/tutor-sandbox/env` checks from flake8.
