### PR TITLE
refactor: Use importlib.metadata to define version, support Python 3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,6 +14,7 @@ jobs:
           - 3.9
           - "3.10"
           - 3.11
+          - 3.12
 
     steps:
     - name: Check out code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support Tutor 17 and Open edX Quince.
+
 ## Version 1.2.0 (2023-07-21)
 
 * [Enhancement] Support Tutor 16 and Open edX Palm, Python 3.10, and Python 3.11.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * [Enhancement] Support Tutor 17 and Open edX Quince.
+* [Enhancement] Support Python 3.12, add it to the test matrix.
 
 ## Version 1.2.0 (2023-07-21)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ appropriate one:
 | Nutmeg           | `>=14.0, <15`     | `main`        | 1.0.x          |
 | Olive            | `>=15.0, <16`     | `main`        | 1.1.x          |
 | Palm             | `>=16.0, <17`     | `main`        | 1.2.x          |
+| Quince           | `>=17.0, <18`     | `main`        | 1.3.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <17, >=14.0.0"],
+    install_requires=["tutor <18, >=14.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={"tutor.plugin.v1": ["s3 = tutors3.plugin"]},
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = gitlint,py{38,39,310,311},flake8
+envlist = gitlint,py{38,39,310,311,312},flake8
 
 [gh-actions]
 python =
@@ -7,6 +7,7 @@ python =
     3.9: gitlint,py39,flake8
     3.10: gitlint,py310,flake8
     3.11: gitlint,py311,flake8
+    3.12: gitlint,py312,flake8
 
 [flake8]
 ignore = E124,W504

--- a/tutors3/__about__.py
+++ b/tutors3/__about__.py
@@ -1,8 +1,8 @@
-import pkg_resources
+from importlib import metadata
 # __version__ attribute as suggested by (deferred) PEP 396:
 # https://www.python.org/dev/peps/pep-0396/
 #
 # Single-source package definition as suggested (among several
 # options) by:
 # https://packaging.python.org/guides/single-sourcing-package-version/
-__version__ = pkg_resources.get_distribution('tutor-contrib-s3').version
+__version__ = metadata.version('tutor-contrib-s3')


### PR DESCRIPTION
We previously made use of the `pkg_resources` module to determine the package version (as defined by `setuptools-scm`) in `__about__.py`. This module is included in `setuptools`, which as of Python 3.12 has been removed from the standard library and is now its own third-party package.

There are multiple ways to address this, one being to include `setuptools` in the `install_requires` list for Python 3.12 and later. Another, also listed in the Python Packaging User Guide, is to instead use `importlib.metadata.version`. Since this approach works for all Python versions we intend to support (that is, from 3.8 forward), this is the better solution.

Thus, refactor `__about__.py` to use `importlib`, and add Python 3.12 to the test matrix.

Reference:
https://packaging.python.org/en/latest/guides/single-sourcing-package-version/