### PR TITLE
Reintroduced base url for dev environment

### DIFF
--- a/tutors3/patches/openedx-lms-development-settings
+++ b/tutors3/patches/openedx-lms-development-settings
@@ -1,0 +1,3 @@
+{% if S3_PROFILE_IMAGE_BUCKET %}
+PROFILE_IMAGE_BACKEND["options"]["base_url"] = "dummyprofileimagebaseurl"
+{% endif %}


### PR DESCRIPTION
Readded base url as it is still needed in the dev environment. I have added it in the dev patch instead of common.
```
lms-1  |   File "/openedx/edx-platform/lms/urls.py", line 930, in <module>
lms-1  |     settings.PROFILE_IMAGE_BACKEND['options']['base_url'],
lms-1  | KeyError: 'base_url'
```