### PR TITLE
chore: bump supported tutor versions to work on tutor 18 for redwood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support Tutor 18 and Open edX Redwood.
+
 ## Version 1.4.0 (2024-04-05)
 
 * [Enhancement] Support Python 3.12.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ appropriate one:
 | Olive            | `>=15.0, <16`     | `main`        | 1.1.x          |
 | Palm             | `>=16.0, <17`     | `main`        | 1.2.x          |
 | Quince           | `>=17.0, <18`     | `main`        | >=1.3.0        |
+| Redwood          | `>=18.0, <19`     | `main`        | >=1.4.0        |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <18, >=14.0.0"],
+    install_requires=["tutor <19, >=14.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={"tutor.plugin.v1": ["s3 = tutors3.plugin"]},
     classifiers=[


### PR DESCRIPTION
## Description

Add support for tutor 18 (Redwood)

## Other information

Private Ref : OpenCraft Internal ticket [BB-8942](https://tasks.opencraft.com/browse/BB-8942)