### PR TITLE
chore: bump supported Tutor versions to work on Tutor 18 for Redwood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support Tutor 18 and Open edX Redwood.
+
 ## Version 1.4.0 (2024-04-05)
 
 * [Enhancement] Support Python 3.12.

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ edX and Tutor version you are deploying. If you are installing this
 plugin from a branch in this Git repository, you must select the
 appropriate one:
 
-| Open edX release | Tutor version     | Plugin branch | Plugin release |
-|------------------|-------------------|---------------|----------------|
-| Lilac            | `>=12.0, <13`     | Not supported | Not supported  |
-| Maple            | `>=13.2, <14`[^1] | `maple`       | 0.3.x          |
-| Nutmeg           | `>=14.0, <15`     | `main`        | 1.0.x          |
-| Olive            | `>=15.0, <16`     | `main`        | 1.1.x          |
-| Palm             | `>=16.0, <17`     | `main`        | 1.2.x          |
-| Quince           | `>=17.0, <18`     | `main`        | >=1.3.0        |
+| Open edX release | Tutor version     | Plugin branch | Plugin release   |
+|------------------|-------------------|---------------|----------------- |
+| Lilac            | `>=12.0, <13`     | Not supported | Not supported    |
+| Maple            | `>=13.2, <14`[^1] | `maple`       | 0.3.x            |
+| Nutmeg           | `>=14.0, <15`     | `main`        | 1.0.x            |
+| Olive            | `>=15.0, <16`     | `main`        | 1.1.x            |
+| Palm             | `>=16.0, <17`     | `main`        | 1.2.x            |
+| Quince           | `>=17.0, <18`     | `main`        | >=1.3.0, < 1.5.0 |
+| Redwood          | `>=18.0, <19`     | `main`        | >=1.5.0          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <18, >=14.0.0"],
+    install_requires=["tutor <19, >=14.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={"tutor.plugin.v1": ["s3 = tutors3.plugin"]},
     classifiers=[


### PR DESCRIPTION
# Description

This PR bumps Tutor to v17 to support Quince. Also, it updates the changelog and the compatibility matrix.