### PR TITLE
Set AWS_DEFAULT_ACL based on S3_DEFAULT_ACL config

### DIFF
--- a/tutors3/patches/openedx-common-settings
+++ b/tutors3/patches/openedx-common-settings
@@ -15,7 +15,7 @@ AWS_S3_ENDPOINT_URL = "{{ "https" if S3_USE_SSL else "http" }}://{{ S3_HOST }}{%
 
 AWS_S3_USE_SSL = {{ "True" if S3_USE_SSL else "False" }}
 AWS_S3_SECURE_URLS = {{ "True" if S3_USE_SSL else "False" }}
-AWS_DEFAULT_ACL = None # inherit from the bucket
+AWS_DEFAULT_ACL = {{ '"{}"'.format(S3_DEFAULT_ACL) if S3_DEFAULT_ACL is defined else 'None' }} # None - inherit from the bucket
 AWS_S3_ADDRESSING_STYLE = "{{ S3_ADDRESSING_STYLE }}"
 AWS_AUTO_CREATE_BUCKET = False
 


### PR DESCRIPTION
Add ability to set AWS_DEFAULT_ACL. Useful when you don't want to set bucket as public but still want handle profile images. By default the value remains the same  -`None`.