### PR TITLE
feat: Introduce S3_DEFAULT_ACL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Introduce `S3_DEFAULT_ACL` configuration option.
+
 ## Version 1.5.0 (2024-08-08)
 
 * [Enhancement] Support Tutor 18 and Open edX Redwood.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Plugin configuration
 
 * `OPENEDX_AWS_ACCESS_KEY` (default: `""`)
 * `OPENEDX_AWS_SECRET_ACCESS_KEY` (default: `""`)
-* `S3_HOST` (default: `""`) - set only if using any other service than AWS S3
-* `S3_PORT` (default: `""`) - set only if using any other service than AWS S3
+* `S3_HOST` (default: `""`) — set only if using any other service than AWS S3
+* `S3_PORT` (default: `""`) — set only if using any other service than AWS S3
 * `S3_REGION` (default: `""`)
 * `S3_USE_SSL` (default: `true`)
 * `S3_STORAGE_BUCKET` (default: `"openedx"`)
@@ -60,15 +60,15 @@ Plugin configuration
 * `S3_GRADE_BUCKET` (default: `"{{ S3_STORAGE_BUCKET }}"`)
 * `S3_ADDRESSING_STYLE` (default: `"auto"`)
 * `S3_SIGNATURE_VERSION` (default: `"s3v4"`)
-* `S3_CUSTOM_DOMAIN` (default: `""`) - do not set if you are using AWS S3
+* `S3_CUSTOM_DOMAIN` (default: `""`) — do not set if you are using AWS S3
 * `S3_PROFILE_IMAGE_CUSTOM_DOMAIN` (default: `""`)
 * `S3_DEFAULT_ACL` (default: `None`[^null], meaning inherit from the parent bucket and fall back to the S3 provider's default canned ACL[^private] if unset)
 
 These values can be modified by the `tutor config save --set
 PARAM_NAME=VALUE` command, or by setting them in `$(tutor config
-printroot)/config.yaml`.
+printroot)/config.yml`.
 
-[^null]: If you want to explicitly set a value to None in `config.yaml`, use `!!null`.
+[^null]: If you want to explicitly set a value to None in `config.yml`, use `!!null`.
 
 [^private]: In AWS S3, the default ACL is `private`.
 
@@ -81,7 +81,7 @@ service, some of these values may be required to set.
 * If you want to use an alternative S3-compatible service, you need to set the
   `S3_HOST` and `S3_PORT` parameters.
 * For a Ceph Object Gateway that doesn’t set
-  [rgw_dns_name](https://docs.ceph.com/en/latest/radosgw/config-ref/#confval-rgw_dns_name),
+  [`rgw_dns_name`](https://docs.ceph.com/en/latest/radosgw/config-ref/#confval-rgw_dns_name),
   you will need `S3_ADDRESSING_STYLE: path`.
 * Due to limitations in Open edX, if you are using `s3v4` signatures, your
   `S3_PROFILE_IMAGE_BUCKET` must have a public ACL and you must set

--- a/README.md
+++ b/README.md
@@ -62,10 +62,15 @@ Plugin configuration
 * `S3_SIGNATURE_VERSION` (default: `"s3v4"`)
 * `S3_CUSTOM_DOMAIN` (default: `""`) - do not set if you are using AWS S3
 * `S3_PROFILE_IMAGE_CUSTOM_DOMAIN` (default: `""`)
+* `S3_DEFAULT_ACL` (default: `None`[^null], meaning inherit from the parent bucket and fall back to the S3 provider's default canned ACL[^private] if unset)
 
 These values can be modified by the `tutor config save --set
 PARAM_NAME=VALUE` command, or by setting them in `$(tutor config
 printroot)/config.yaml`.
+
+[^null]: If you want to explicitly set a value to None in `config.yaml`, use `!!null`.
+
+[^private]: In AWS S3, the default ACL is `private`.
 
 Depending on the nature and configuration of your S3-compatible
 service, some of these values may be required to set.

--- a/tutors3/patches/openedx-common-settings
+++ b/tutors3/patches/openedx-common-settings
@@ -15,7 +15,7 @@ AWS_S3_ENDPOINT_URL = "{{ "https" if S3_USE_SSL else "http" }}://{{ S3_HOST }}{%
 
 AWS_S3_USE_SSL = {{ "True" if S3_USE_SSL else "False" }}
 AWS_S3_SECURE_URLS = {{ "True" if S3_USE_SSL else "False" }}
-AWS_DEFAULT_ACL = None # inherit from the bucket
+AWS_DEFAULT_ACL = {% if S3_DEFAULT_ACL %}"{{ S3_DEFAULT_ACL }}"{% else %}None{% endif %}
 AWS_S3_ADDRESSING_STYLE = "{{ S3_ADDRESSING_STYLE }}"
 AWS_AUTO_CREATE_BUCKET = False
 

--- a/tutors3/plugin.py
+++ b/tutors3/plugin.py
@@ -28,6 +28,7 @@ config = {
         "ADDRESSING_STYLE": "auto",
         "SIGNATURE_VERSION": "s3v4",
         "CUSTOM_DOMAIN": "",
+        "DEFAULT_ACL": None,
     },
 }
 


### PR DESCRIPTION
Introduce a new configuration option, `S3_DEFAULT_ACL`, defaulting to `None`.

When set, this populates the `AWS_DEFAULT_ACL` option for the S3Storage backend.

Reference:
https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings
