### PR TITLE
Bump GitHub Actions 

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,7 +24,7 @@ jobs:
         # commit, so that gitlint lints the correct commit message.
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # Checkout a pull request's HEAD commit instead of the merge
         # commit, so that gitlint lints the correct commit message.


### PR DESCRIPTION
These are substantially the same changes as in https://github.com/hastexo/tutor-contrib-backup/pull/87 (minus the README updates).