### PR TITLE
fix: Include the AWS_S3_CLIENT_CONFIG setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* [Enhancement] Set the `AWS_S3_CLIENT_CONFIG` variable in addition to the
+  individual `AWS_S3_SIGNATURE_VERSION`, `AWS_REQUEST_CHECKSUM_CALCULATION` and
+  `AWS_S3_ADDRESSING_STYLE` settings.
 * [Enhancement] Support Tutor 20 and Open edX Teak.
 
 ## Version 2.2.0 (2025-04-24)

--- a/tutors3/patches/openedx-common-settings
+++ b/tutors3/patches/openedx-common-settings
@@ -22,3 +22,9 @@ AWS_AUTO_CREATE_BUCKET = False
 
 AWS_S3_REGION_NAME = "{{ S3_REGION }}"
 AWS_QUERYSTRING_EXPIRE = 7 * 24 * 60 * 60  # 1 week: this is necessary to generate valid download urls
+
+AWS_S3_CLIENT_CONFIG = Config(
+    signature_version=AWS_S3_SIGNATURE_VERSION,
+    request_checksum_calculation=AWS_REQUEST_CHECKSUM_CALCULATION,
+    s3={"addressing_style": AWS_S3_ADDRESSING_STYLE}
+)


### PR DESCRIPTION
Set the `AWS_S3_CLIENT_CONFIG` variable in addition to the individual `AWS_S3_SIGNATURE_VERSION`, `AWS_REQUEST_CHECKSUM_CALCULATION` and `AWS_S3_ADDRESSING_STYLE` settings.