### PR TITLE
fix: Add missing import statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Fix] Add the missing import statement for `botocore.client import Config`.
+
 ## Version 2.3.0 (2025-07-29)
 
 * [Enhancement] Set the `AWS_S3_CLIENT_CONFIG` variable in addition to the

--- a/tutors3/patches/openedx-common-settings
+++ b/tutors3/patches/openedx-common-settings
@@ -23,6 +23,8 @@ AWS_AUTO_CREATE_BUCKET = False
 AWS_S3_REGION_NAME = "{{ S3_REGION }}"
 AWS_QUERYSTRING_EXPIRE = 7 * 24 * 60 * 60  # 1 week: this is necessary to generate valid download urls
 
+from botocore.client import Config
+
 AWS_S3_CLIENT_CONFIG = Config(
     signature_version=AWS_S3_SIGNATURE_VERSION,
     request_checksum_calculation=AWS_REQUEST_CHECKSUM_CALCULATION,


### PR DESCRIPTION
Add the missing import statement for `botocore.client import Config` when setting the AWS_S3_CLIENT_CONFIG variable.