### PR TITLE
docs: Update README and CHANGELOG to mention repo move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Point release to mark the GitHub repository move.
+
 ## Version 2.4.0 (2025-09-12)
 
 * [Chore] Replace deprecated setting `DEFAULT_FILE_STORAGE` with `STORAGES['default']['BACKEND']`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This plugin is meant to make Tutor-managed Open edX interface with S3
 S3-compatible storage platform *as part of Tutor,* please consider the
 [minio](https://github.com/overhangio/tutor-minio) Tutor plugin.
 
+This repository was previously hosted under the `hastexo` GitHub organization, and moved to `cleura` in December 2025 as part of a routine repository consolidation.
+
 Version compatibility matrix
 ----------------------------
 
@@ -41,7 +43,7 @@ appropriate one:
 Installation
 ------------
 
-    pip install git+https://github.com/hastexo/tutor-contrib-s3@v2.4.0
+    pip install git+https://github.com/cleura/tutor-contrib-s3@v2.4.0
 
 Then, to enable this plugin, run:
 

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ with io.open(os.path.join(here, "README.md"), "rt", encoding="utf8") as f:
 setup(
     name="tutor-contrib-s3",
     use_scm_version=True,
-    url="https://github.com/hastexo/tutor-contrib-s3/",
+    url="https://github.com/cleura/tutor-contrib-s3/",
     project_urls={
-        "Code": "https://github.com/hastexo/tutor-contrib-s3",
-        "Issue tracker": "https://github.com/hastexo/tutor-contrib-s3/issues",
+        "Code": "https://github.com/cleura/tutor-contrib-s3",
+        "Issue tracker": "https://github.com/cleura/tutor-contrib-s3/issues",
     },
     license="AGPLv3",
     author='hastexo',


### PR DESCRIPTION
Mention that the repo has been moved from the hastexo to the cleura org.