### PR TITLE
feat: Disable querystring authentication for profile image backed

### DIFF
--- a/tutors3/patches/openedx-lms-common-settings
+++ b/tutors3/patches/openedx-lms-common-settings
@@ -4,6 +4,7 @@ PROFILE_IMAGE_BACKEND = {
     "options": {
         "bucket_name": "{{ S3_PROFILE_IMAGE_BUCKET }}",
         "location": PROFILE_IMAGE_BACKEND["options"]["location"].lstrip("/"),
+        "querystring_auth": False,
         {% if S3_PROFILE_IMAGE_CUSTOM_DOMAIN %}"custom_domain": "{{ S3_PROFILE_IMAGE_CUSTOM_DOMAIN }}",{% endif %}
     },
 }


### PR DESCRIPTION
Added a new option to the S3 profile image backend configuration to set querystring authentication to false.

---
When AWS_QUERYSTRING_AUTH is enabled globally for private S3 buckets, profile image URLs are also generated with signed query parameters. If profile images are stored in a separate public bucket (e.g. via S3_PROFILE_IMAGE_BUCKET), those signed URLs are unnecessary and prevents images from loading correctly.
This change sets querystring_auth: False on the profile image backend only. Other storage (default bucket, grades, file uploads, etc.) still use the global querystring auth setting; only the profile image backend generates plain URLs suitable for a public bucket.