### PR TITLE
feat: bump supported tutor versions to work on tutor 22 for verawood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [Testing] Set skip_missing_interpreters = true for tox, so that it runs with whatever Python is available.
 * [Chore] Use full repo path for skills submodule.
+* [Enhancement] Support Tutor 22 and Open edX Verawood.
 
 ## Version 2.5.0 (2026-01-27)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you are installing this plugin from a branch in this Git repository, you must
 | Sumac            | `>=19.0, <20`     | `teak`        | `>=2.1.0`      |
 | Teak             | `>=20.0, <21`     | `teak`        | `>=2.3.1, <2.5`|
 | Ulmo             | `>=21.0, <22`     | `main`        | `>=2.5.0`      |
+| Verawood         | `>=22.0, <23`     | `main`        | `>=2.6.0`      |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or later. 
       That is because this plugin uses the Tutor v1 plugin API, [which was introduced with that release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.9",
-    install_requires=["tutor <22, >=14.0.0"],
+    install_requires=["tutor <23, >=14.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={"tutor.plugin.v1": ["s3 = tutors3.plugin"]},
     classifiers=[


### PR DESCRIPTION
Description
This PR adds support for tutor 22 (Verawood)

Other information
Private Ref : OpenCraft Internal ticket [BB-10831](https://tasks.opencraft.com/browse/BB-10831)