### PR TITLE
chore: use full path skills submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".agents/skills"]
 	path = .agents/skills
-	url = ../skills
+	url = https://github.com/cleura/skills.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* [Chore] Use full repo path for skills submodule.
+
 ## Version 2.5.0 (2026-01-27)
 
 * [Enhancement] Support Tutor 21 and Open edX Ulmo.


### PR DESCRIPTION
Description

The PR replaces the relative path for skills submodule with the full git path so tutor builds using fork of this repo works correctly

Other information
Private Ref : OpenCraft Internal ticket [BB-10831](https://tasks.opencraft.com/browse/BB-10831)